### PR TITLE
resolves #1 - Use FormattableString.Invariant for RouteRequestDirections 

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -175,7 +175,7 @@ namespace refrigerated_truck
 
             var req = new RouteRequestDirections
             {
-                Query = $"{currentLat},{currentLon}:{destinationLat},{destinationLon}"
+                Query = FormattableString.Invariant($"{currentLat},{currentLon}:{destinationLat},{destinationLon}")
             };
             var directions = azureMapsServices.GetRouteDirections(req).Result;
 


### PR DESCRIPTION
Use FormattableString.Invariant to ensure RouteRequestDirections handles non-english cultures