### PR TITLE
Send temperature as numeric

### DIFF
--- a/app.js
+++ b/app.js
@@ -453,7 +453,7 @@ function sendTruckTelemetry() {
         {
             // Format is:  
             // Field name from IoT Central app ":" variable name from NodeJS app.
-            ContentsTemperature: temp.toFixed(2),
+            ContentsTemperature: Math.round(temp * 100)/100,
             TruckState: state,
             CoolingSystemState: fan,
             ContentsState: contents,


### PR DESCRIPTION
Doing the MS Learning Set up Continuous data export from Azure IoT Central to a Pwoer BI app, the value cannot be graphed as it is coming through as text, not a number. This is using the Node.js version of the app.

The relevant MS Learning task is: https://docs.microsoft.com/en-gb/learn/modules/continuously-export-data-from-iot-central-power-bi/7-exercise-create-powerbi-app-view-your-data-remotely

When building the PowerBI dashboard guage the only value available was PartitionId, not CurrentTemperature. Checking the dataset, temperature was coming through as Text, not Number.

Looking at the continuousjob data, it was a string, and looking at the console output of app.js it was being sent as a string. 

Checking the Node app.js code, it was sending it converted to a 2 decimal place *string* using toFixed(2).  This pull request changes it to send as a number (it still rounds it to two decimal places). 

When this fix is applied, the data can then be graphed in Power BI. (You may need to stop the continuousjob, delete the data set in PowerBI, and restart the job to recreate the set with the correct types)
