### PR TITLE
Removed Unit from SetOptimalTemperature command

### DIFF
--- a/Refrigerated Truck Capability Model.json
+++ b/Refrigerated Truck Capability Model.json
@@ -243,8 +243,7 @@
                 "en": "Optimal temperature"
               },
               "name": "OptimalTemperature",
-              "schema": "double",
-              "unit": "Units/Temperature/celsius"
+              "schema": "double"
             },
             "displayName": {
               "en": "Set optimal temperature"


### PR DESCRIPTION
Context:

[Microsoft Learn - Prepare the IoT Central app](https://docs.microsoft.com/en-us/learn/modules/set-up-rules-take-actions-telemetry-data-azure-iot-central/2-create-iot-central-apps-device-template?pivots=vs-csharp)

Following the steps detailed on the aforementioned tutorial, I came across an issue trying to import this model, apparently, due to an invalid property included in the command `SetOptimalTemperature`.

Error description:

> Encountered one or more errors while validating json-ld model: {"urn:refrigeratedtrucks:Refrigerated_Truck_226:SetOptimalTemperature:OptimalTemperature:1":[{"instanceId":"urn:refrigeratedtrucks:Refrigerated_Truck_226:SetOptimalTemperature:OptimalTemperature:1","errorCode":"400.804.006.107","message":"Found invalid reference properties on SchemaField urn:refrigeratedtrucks:Refrigerated_Truck_226:SetOptimalTemperature:OptimalTemperature:1. Reference properties [unit] are not allowed on SchemaField urn:refrigeratedtrucks:Refrigerated_Truck_226:SetOptimalTemperature:OptimalTemperature:1","propertyName":"vertex"}]}.
Error code: 400.470.006.309 / eutyvfpoxq.9

![image](https://user-images.githubusercontent.com/3358683/97185897-681dc900-177f-11eb-86ea-d5bb21e88209.png)

Thanks